### PR TITLE
Fix crashes on dedi by refactoring sound registry and moving some stuff

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.16.3
 yarn_mappings=1.16.3+build.17
 loader_version=0.10.0+build.208
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=team.comofas
 archives_base_name=arstheurgia
 # Dependencies

--- a/src/main/java/team/comofas/arstheurgia/ArsTheurgia.java
+++ b/src/main/java/team/comofas/arstheurgia/ArsTheurgia.java
@@ -1,7 +1,6 @@
 package team.comofas.arstheurgia;
 
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityRendererRegistry;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
 import net.minecraft.entity.EntityDimensions;
@@ -13,10 +12,6 @@ import team.comofas.arstheurgia.entity.AnzuEntity;
 import team.comofas.arstheurgia.entity.LamassuEntity;
 import team.comofas.arstheurgia.entity.TormentedCreeperEntity;
 import team.comofas.arstheurgia.entity.UdugEntity;
-import team.comofas.arstheurgia.entity.anzu.AnzuEntityRenderer;
-import team.comofas.arstheurgia.entity.lamassu.LamassuEntityRenderer;
-import team.comofas.arstheurgia.entity.tormentedcreeper.TormentedCreeperEntityRenderer;
-import team.comofas.arstheurgia.entity.udug.UdugEntityRenderer;
 import team.comofas.arstheurgia.events.LootTableEvent;
 import team.comofas.arstheurgia.registry.*;
 
@@ -52,7 +47,7 @@ public class ArsTheurgia implements ModInitializer {
     @Override
     public void onInitialize() {
 
-        ArsSounds.registerAll();
+        ArsSounds.init();
         ArsBlocks.registerAll();
         ArsItems.registerAll();
         ArsEffects.registerAll();
@@ -66,14 +61,5 @@ public class ArsTheurgia implements ModInitializer {
         FabricDefaultAttributeRegistry.register(ANZU, AnzuEntity.createMobAttributes());
 
         FabricDefaultAttributeRegistry.register(TORMENTEDCREEPER, TormentedCreeperEntity.createAttributes());
-
-        EntityRendererRegistry.INSTANCE.register(ArsTheurgia.UDUG, (dispatcher, context) -> new UdugEntityRenderer(dispatcher));
-
-        EntityRendererRegistry.INSTANCE.register(ArsTheurgia.LAMASSU, (dispatcher, context) -> new LamassuEntityRenderer(dispatcher));
-
-        EntityRendererRegistry.INSTANCE.register(ArsTheurgia.ANZU, (dispatcher, context) -> new AnzuEntityRenderer(dispatcher));
-
-        EntityRendererRegistry.INSTANCE.register(ArsTheurgia.TORMENTEDCREEPER, (dispatcher, context) -> new TormentedCreeperEntityRenderer(dispatcher));
-
     }
 }

--- a/src/main/java/team/comofas/arstheurgia/ArsTheurgiaClient.java
+++ b/src/main/java/team/comofas/arstheurgia/ArsTheurgiaClient.java
@@ -3,17 +3,19 @@ package team.comofas.arstheurgia;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.blockrenderlayer.v1.BlockRenderLayerMap;
 import net.fabricmc.fabric.api.client.rendereregistry.v1.BlockEntityRendererRegistry;
+import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityRendererRegistry;
 import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
-import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.render.RenderLayer;
-import net.minecraft.item.ItemStack;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.util.math.BlockPos;
-import team.comofas.arstheurgia.blocks.ceramicaltar.CeramicAltarBlockEntityRenderer;
 import team.comofas.arstheurgia.blocks.RitualBlockEntityRenderer;
-import team.comofas.arstheurgia.blocks.table.TableBlockEntity;
+import team.comofas.arstheurgia.blocks.ceramicaltar.CeramicAltarBlockEntityRenderer;
 import team.comofas.arstheurgia.blocks.table.TableBlockEntityRenderer;
+import team.comofas.arstheurgia.entity.anzu.AnzuEntityRenderer;
+import team.comofas.arstheurgia.entity.lamassu.LamassuEntityRenderer;
+import team.comofas.arstheurgia.entity.tormentedcreeper.TormentedCreeperEntityRenderer;
+import team.comofas.arstheurgia.entity.udug.UdugEntityRenderer;
 import team.comofas.arstheurgia.registry.ArsBlocks;
 
 public class ArsTheurgiaClient implements ClientModInitializer {
@@ -21,8 +23,9 @@ public class ArsTheurgiaClient implements ClientModInitializer {
     public void onInitializeClient() {
         BlockEntityRendererRegistry.INSTANCE.register(ArsBlocks.RITUALBLOCK_ENTITY, RitualBlockEntityRenderer::new);
         BlockEntityRendererRegistry.INSTANCE.register(ArsBlocks.CERAMIC_ALTAR_ENTITY, CeramicAltarBlockEntityRenderer::new);
-
         BlockEntityRendererRegistry.INSTANCE.register(ArsBlocks.TABLE_BLOCK_ENTITY, TableBlockEntityRenderer::new);
+
+        // Setup block render layers
         BlockRenderLayerMap.INSTANCE.putBlock(ArsBlocks.ASYRIEL_SIGIL, RenderLayer.getCutout());
         BlockRenderLayerMap.INSTANCE.putBlock(ArsBlocks.AUTUMN_SYMBOL, RenderLayer.getCutout());
         BlockRenderLayerMap.INSTANCE.putBlock(ArsBlocks.SPRING_SYMBOL, RenderLayer.getCutout());
@@ -30,6 +33,13 @@ public class ArsTheurgiaClient implements ClientModInitializer {
         BlockRenderLayerMap.INSTANCE.putBlock(ArsBlocks.WINTER_SYMBOL, RenderLayer.getCutout());
         BlockRenderLayerMap.INSTANCE.putBlock(ArsBlocks.FLOUR, RenderLayer.getCutout());
         BlockRenderLayerMap.INSTANCE.putBlock(ArsBlocks.MIRSU_BOWL, RenderLayer.getCutout());
+        BlockRenderLayerMap.INSTANCE.putBlock(ArsBlocks.DATE_SAPLING, RenderLayer.getCutout());
+
+        // Register Entity Renderers
+        EntityRendererRegistry.INSTANCE.register(ArsTheurgia.UDUG, (dispatcher, context) -> new UdugEntityRenderer(dispatcher));
+        EntityRendererRegistry.INSTANCE.register(ArsTheurgia.LAMASSU, (dispatcher, context) -> new LamassuEntityRenderer(dispatcher));
+        EntityRendererRegistry.INSTANCE.register(ArsTheurgia.ANZU, (dispatcher, context) -> new AnzuEntityRenderer(dispatcher));
+        EntityRendererRegistry.INSTANCE.register(ArsTheurgia.TORMENTEDCREEPER, (dispatcher, context) -> new TormentedCreeperEntityRenderer(dispatcher));
 
         ClientSidePacketRegistry.INSTANCE.register(ArsTheurgia.CONSUME_ITEM_PARTICLE,
                 (packetContext, attachedData) -> {
@@ -44,7 +54,5 @@ public class ArsTheurgiaClient implements ClientModInitializer {
 
                     });
                 });
-
-
     }
 }

--- a/src/main/java/team/comofas/arstheurgia/registry/ArsBlocks.java
+++ b/src/main/java/team/comofas/arstheurgia/registry/ArsBlocks.java
@@ -93,7 +93,6 @@ public class ArsBlocks {
         registerBlock(DATE_TREE_LOG, "date_logs");
         registerBlock(DATE_LEAVES, "date_leaves");
         registerBlock(DATE_SAPLING, "date_sapling");
-        BlockRenderLayerMap.INSTANCE.putBlock(DATE_SAPLING, RenderLayer.getCutout());
 
         registerBlock(SAMAS_FIGURINE, "shamash");
         registerBlock(MIRSU_BOWL, "mirsu_bowl");

--- a/src/main/java/team/comofas/arstheurgia/registry/ArsSounds.java
+++ b/src/main/java/team/comofas/arstheurgia/registry/ArsSounds.java
@@ -1,46 +1,33 @@
 package team.comofas.arstheurgia.registry;
 
 import net.minecraft.sound.SoundEvent;
+import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 import team.comofas.arstheurgia.ArsUtils;
 
 public class ArsSounds {
-    public static SoundEvent CHALK = new SoundEvent(ArsUtils.getIdentifier("chalk"));
-    public static SoundEvent RITUAL_FAIL = new SoundEvent(ArsUtils.getIdentifier("ritual_fail"));
-    public static SoundEvent RITUAL_CHIME = new SoundEvent(ArsUtils.getIdentifier("ritual_chime"));
-    public static SoundEvent UDUG_DISAPPEAR = new SoundEvent(ArsUtils.getIdentifier("udug_disappear"));
-    public static SoundEvent UDUG_AMBIENT = new SoundEvent(ArsUtils.getIdentifier("udug_ambient"));
-    public static SoundEvent UDUG_WALKING = new SoundEvent(ArsUtils.getIdentifier("udug_walking"));
-    public static SoundEvent COLLECT_BILE = new SoundEvent(ArsUtils.getIdentifier("collect_bile"));
-    public static SoundEvent LAMASSU_WINGFLAP = new SoundEvent(ArsUtils.getIdentifier("lamassu_wingflap"));
-    public static SoundEvent CLAWS_ATTACK = new SoundEvent(ArsUtils.getIdentifier("claws_attack"));
-    public static SoundEvent LAMASSU_AMBIENT = new SoundEvent(ArsUtils.getIdentifier("lamassu_ambient"));
-    public static SoundEvent ANZU_WINGFLAP = new SoundEvent(ArsUtils.getIdentifier("anzu_wingflap"));
-    public static SoundEvent CLAWS_GROW = new SoundEvent(ArsUtils.getIdentifier("claws_grow"));
-    public static SoundEvent MACE_PULL = new SoundEvent(ArsUtils.getIdentifier("mace_pull"));
-    public static SoundEvent MACE_SPIN = new SoundEvent(ArsUtils.getIdentifier("mace_spin"));
-    public static SoundEvent IMHULLU_WIND = new SoundEvent(ArsUtils.getIdentifier("imhullu_wind"));
+    public static SoundEvent CHALK = registerSound("chalk");
+    public static SoundEvent RITUAL_FAIL = registerSound("ritual_fail");
+    public static SoundEvent RITUAL_CHIME = registerSound("ritual_chime");
+    public static SoundEvent UDUG_DISAPPEAR = registerSound("udug_disappear");
+    public static SoundEvent UDUG_AMBIENT = registerSound("udug_ambient");
+    public static SoundEvent UDUG_WALKING = registerSound("udug_walking");
+    public static SoundEvent COLLECT_BILE = registerSound("collect_bile");
+    public static SoundEvent LAMASSU_WINGFLAP = registerSound("lamassu_wingflap");
+    public static SoundEvent CLAWS_ATTACK = registerSound("claws_attack");
+    public static SoundEvent LAMASSU_AMBIENT = registerSound("lamassu_ambient");
+    public static SoundEvent ANZU_WINGFLAP = registerSound("anzu_wingflap");
+    public static SoundEvent CLAWS_GROW = registerSound("claws_grow");
+    public static SoundEvent MACE_PULL = registerSound("mace_pull");
+    public static SoundEvent MACE_SPIN = registerSound("mace_spin");
+    public static SoundEvent IMHULLU_WIND = registerSound("imhullu_wind");
 
-
-    public static void registerAll() {
-        registerSound(CHALK);
-        registerSound(RITUAL_FAIL);
-        registerSound(RITUAL_CHIME);
-        registerSound(UDUG_AMBIENT);
-        registerSound(UDUG_DISAPPEAR);
-        registerSound(UDUG_WALKING);
-        registerSound(COLLECT_BILE);
-        registerSound(LAMASSU_WINGFLAP);
-        registerSound(LAMASSU_AMBIENT);
-        registerSound(ANZU_WINGFLAP);
-        registerSound(CLAWS_ATTACK);
-        registerSound(CLAWS_GROW);
-        registerSound(MACE_PULL);
-        registerSound(MACE_SPIN);
-        registerSound(IMHULLU_WIND);
+    public static void init() {
+        // NO-OP, forces static fields to load
     }
 
-    public static SoundEvent registerSound(SoundEvent sound) {
-        return Registry.register(Registry.SOUND_EVENT, sound.getId(), sound);
+    public static SoundEvent registerSound(String name) {
+        Identifier id = ArsUtils.getIdentifier(name);
+        return Registry.register(Registry.SOUND_EVENT, id, new SoundEvent(id));
     }
 }


### PR DESCRIPTION
There were a few things that needed to be on the client in your general init class, so I moved them to the proper location. 

There was also a small issue with your sound registry; basically, `SoundEvent#getId()` is client-only, so it crashes on a server with your current setup. I fixed this by refactoring your sound registry class to pass identifiers to the registry method instead. 

Tested and working on 1.16.3 server, let me know if you want me to change anything. Mod version was bumped to 1.0.2.